### PR TITLE
Update README and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,14 +16,14 @@ A state actor represents a mode in the flight plan. A mode represents the set of
 ---
 The decision to switch to the next mode is taken by the parent based on the state table. The state table consists of multiple rows containing the current state, inputs (represented through an input bitmask) and the next state.
 ##### Input Bitmask
-The input bitmask consists of an array of cells. Each cell can either be a 0, 1 or X (Don't care). This array is used by the parent to switch to the next state. For example, let a machine be in state A, which will switch to state B if its input mask is of the form 1X0X. Now, if our current inputs were represented by 1100, 1101, 1001 or 1000, then we would switch to state B. To implement the X symbol, we use 2 binary bitmasks. These are named bitmask1 and bitmask0. All the X are replaced by 1 in bitmask1 and by 0 in bitmask0. Then in order to check for equality between our input and the input mask, we use the formula : `~(AB + BC + CA) = 0` , where
+The input bitmask consists of an array of cells. Each cell can either be a 0, 1 or X (Don't care). This array is used by the parent to switch to the next state. For example, let a machine be in state A, which will switch to state B if its input mask is of the form 1X0X. Now, if our current inputs were represented by 1100, 1101, 1001 or 1000, then we would switch to state B. To implement the X symbol, we use 2 binary bitmasks. These are named bitmask1 and bitmask0. All the X are replaced by 1 in bitmask1 and by 0 in bitmask0. Then in order to check for equality between our input and the input mask, we use the formula : `(AB + A'C')'` , where
 - A represents the inputs as a binary bitmask
-- B is bitmask1 and
+- B is bitmask1 and'
 - C is bitmask0.
 In the example given above, 1X0X is represented by
 - bitmask1 = 1101 and
 - bitmask0 = 1000
-Now if our input is A = 1100, 1101, 1001 or 1000, then the value of `~(AB + BC + CA)` will be `0`
+Now if our input is A = 1100, 1101, 1001 or 1000, then the value of `(AB + A'C')'` will be `0`
 The following table represents the state table for the Gimbal project (LSB signifies SPI input).
 
 | Current State | Input Bitmask | Next State |
@@ -199,13 +199,13 @@ int init_modes() {
 #### **Input Mask Comparison**
 ```c
 int compare_input_mask(uint8_t inputmask[], row row) {
-    for (int i = 0; i < NO_OF_GROUPS; i++) {
-        if (~((inputmask[i] & row.bitmask1[i]) | (inputmask[i] & row.bitmask0[i]) | (row.bitmask1[i] & row.bitmask0[i]))) {
-            return 0;
+        for (int i = 0; i < NO_OF_GROUPS; i++) {
+                if (~((inputmask[i] & row.bitmask1[i]) | (~inputmask[i] & ~row.bitmask0[i]))) {
+                        return 0;
+                }
         }
-    }
-    return 1;
-}
+        return 1;
+}}
 ```
 - Compares the input mask against the provided row's bitmask and returns `1` if they match, otherwise `0`.
 

--- a/README.md
+++ b/README.md
@@ -170,12 +170,13 @@ state *next_state;
 #### **Row and Mode Initialization**
 
 1. **Add Row Function**
+> Update: Previously, we used `static int index` to increment group and row. In the call to `add_row()`, head would be indexed by `index / NO_OF_GROUPS` which allows for group updation at every call, and row updation every two calls. Changed to direct indexes `row_no` and `group_no` for clarity.
 ```c
 int add_row(row *head, uint8_t bitmask1, uint8_t bitmask0, int group_no, state *next_state) {
-    static int index;
-    head[index / NO_OF_GROUPS].bitmask1[group_no] = bitmask1;
-    head[index / NO_OF_GROUPS].bitmask0[group_no] = bitmask0;
-    head[index++ / NO_OF_GROUPS].next_state = next_state;
+    // static int index;
+    head[row_no].bitmask1[group_no] = bitmask1;
+    head[row_no].bitmask0[group_no] = bitmask0;
+    head[row_no].next_state = next_state;
     return 0;
 }
 ```

--- a/flight_plan.c
+++ b/flight_plan.c
@@ -287,6 +287,9 @@ int main() {
                 init_modes();
                 int status;
                 struct sigaction act;
+                sigset_t mask;
+                sigemptyset(&mask);
+                act.sa_mask = mask;
                 act.sa_sigaction = sigusrhandler;
                 act.sa_flags = SA_SIGINFO;
                 if (sigaction(SIGUSR1, &act, NULL) < 0) {
@@ -313,9 +316,7 @@ int main() {
                         current_state = (next_state = &rotate_state);
                 }
                 kill(spi_id, SIGCONT);
-                sigset_t mask;
-                sigemptyset(&mask);
-                sigaddset(&mask, SIGCLD);
+                
                 for (;;) {
                         pause();
                 }

--- a/flight_plan.c
+++ b/flight_plan.c
@@ -54,7 +54,7 @@ state *next_state;
 // add a row to the state table for a particular state
 int add_row(row *head, uint8_t bitmask1, uint8_t bitmask0, int group_no, int row_no,
             state *next_state) {
-        static int index;
+        // static int index;
         head[row_no].bitmask1[group_no] = bitmask1;
         head[row_no].bitmask0[group_no] = bitmask0;
         head[row_no].next_state = next_state;

--- a/flight_plan.c
+++ b/flight_plan.c
@@ -82,7 +82,7 @@ int compare_input_mask(uint8_t inputmask[], row row) {
 // if A: input
 //    B: bitmask1
 //    C: bitmask0
-//    then A'BC + A'B'C' = 0 will give the next state to go to
+//    then (AB + A'C')' = 0 will give the next state to go to
 void sigstophandler(int signo, siginfo_t *info, void *context) {
         if (signo == SIGTSTP) {
                         flag = 1;

--- a/flight_plan.c
+++ b/flight_plan.c
@@ -72,7 +72,7 @@ int init_modes() {
 
 int compare_input_mask(uint8_t inputmask[], row row) {
         for (int i = 0; i < NO_OF_GROUPS; i++) {
-                if (~((inputmask[i] & row.bitmask1[i]) | (~inputmask[i] & ~row.bitmask0[i]))) {
+                if (~((uint8_t)(inputmask[i] & row.bitmask1[i]) | (uint8_t)(~inputmask[i] & ~row.bitmask0[i]))) {
                         return 0;
                 }
         }


### PR DESCRIPTION
Fix typo error where formula for input mask comparison was incorrectly mentioned as ~(AB + BC + AC) when it should be (AB + A'C')'